### PR TITLE
[MOB-469] Prevent bundling unused icon fonts on iOS

### DIFF
--- a/ios/MobiusMobileWallet.xcodeproj/project.pbxproj
+++ b/ios/MobiusMobileWallet.xcodeproj/project.pbxproj
@@ -370,37 +370,13 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MobiusMobileWallet/Pods-MobiusMobileWallet-resources.sh",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Entypo.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Feather.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Brands.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Regular.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Solid.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Foundation.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Octicons.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Zocial.ttf",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Entypo.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EvilIcons.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Feather.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome5_Brands.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome5_Regular.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome5_Solid.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Foundation.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Ionicons.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialCommunityIcons.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialIcons.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Octicons.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SimpleLineIcons.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Zocial.ttf",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -41,12 +41,15 @@ target 'MobiusMobileWallet' do
   pod 'ReactNativeFabric', path: '../node_modules/react-native-fabric'
   pod 'RNDeviceInfo', path: '../node_modules/react-native-device-info'
   pod 'RNKeychain', path: '../node_modules/react-native-keychain'
-  pod 'RNLanguages', :path => '../node_modules/react-native-languages'
+  pod 'RNLanguages', path: '../node_modules/react-native-languages'
   pod 'RNSVG', path: '../node_modules/react-native-svg'
-  pod 'RNVectorIcons', path: '../node_modules/react-native-vector-icons'
+  pod 'RNVectorIcons', path: '../node_modules/react-native-vector-icons', subspecs: %W[
+    MaterialIcons
+    MaterialCommunityIcons
+  ]
 
-  pod 'react-native-camera', :path => '../node_modules/react-native-camera'
-  pod 'react-native-randombytes', :path => '../node_modules/react-native-randombytes'
+  pod 'react-native-camera', path: '../node_modules/react-native-camera'
+  pod 'react-native-randombytes', path: '../node_modules/react-native-randombytes'
   pod 'react-native-splash-screen', path: '../node_modules/react-native-splash-screen'
 
   target 'MobiusMobileWalletTests' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -87,7 +87,9 @@ PODS:
     - React
   - RNSVG (6.5.2):
     - React
-  - RNVectorIcons (5.0.0):
+  - RNVectorIcons/MaterialCommunityIcons (5.0.0):
+    - React
+  - RNVectorIcons/MaterialIcons (5.0.0):
     - React
   - yoga (0.57.0.React)
 
@@ -123,7 +125,8 @@ DEPENDENCIES:
   - RNKeychain (from `../node_modules/react-native-keychain`)
   - RNLanguages (from `../node_modules/react-native-languages`)
   - RNSVG (from `../node_modules/react-native-svg`)
-  - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
+  - RNVectorIcons/MaterialCommunityIcons (from `../node_modules/react-native-vector-icons`)
+  - RNVectorIcons/MaterialIcons (from `../node_modules/react-native-vector-icons`)
   - yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -184,9 +187,9 @@ SPEC CHECKSUMS:
   RNKeychain: 627c6095cef215dd3d9804a9a9cf45ab96aa3997
   RNLanguages: e3ae05ef105937645218272429dac0c3f7633451
   RNSVG: 6252323c0312735f0af5f58b5adf2965b6a9ffbf
-  RNVectorIcons: c0dbfbf6068fefa240c37b0f71bd03b45dddac44
+  RNVectorIcons: 7e335c36ac85b04f966100980df6c438800fb179
   yoga: b1ce48b6cf950b98deae82838f5173ea7cf89e85
 
-PODFILE CHECKSUM: 337ff846636332fbfa4cffc60b69323a286fbd81
+PODFILE CHECKSUM: 0279226ced65751cf6c5520a0fc173e82e93034a
 
 COCOAPODS: 1.6.0.beta.1

--- a/patches/react-native-vector-icons+5.0.0.patch
+++ b/patches/react-native-vector-icons+5.0.0.patch
@@ -1,4 +1,30 @@
 patch-package
+--- a/node_modules/react-native-vector-icons/RNVectorIcons.podspec
++++ b/node_modules/react-native-vector-icons/RNVectorIcons.podspec
+@@ -11,9 +11,20 @@ Pod::Spec.new do |s|
+   s.author         = { "Joel Arvidsson" => "joel@oblador.se" }
+   s.platform       = :ios, "7.0"
+   s.source         = { :git => "https://github.com/oblador/react-native-vector-icons.git", :tag => "v#{s.version}" }
++
+   s.source_files   = 'RNVectorIconsManager/**/*.{h,m}'
+-  s.resources      = "Fonts/*.ttf"
+   s.preserve_paths = "**/*.js"
+   s.dependency 'React'
+
++  %W[
++    Entypo EvilIcons Feather FontAwesome Foundation Ionicons
++    MaterialIcons MaterialCommunityIcons
++    Octicons Zocial SimpleLineIcons
++  ].each do |iset|
++    s.subspec(iset) { |ss| ss.resources = "Fonts/#{iset}.ttf" }
++  end
++
++  s.subspec 'FontAwesome5' do |ss|
++    ss.resources = "Fonts/FontAwesome5_*.ttf"
++  end
+ end
+diff --git a/node_modules/react-native-vector-icons/android/build.gradle b/node_modules/react-native-vector-icons/android/build.gradle
+index 81ff5f8f..8a90446f 100755
 --- a/node_modules/react-native-vector-icons/android/build.gradle
 +++ b/node_modules/react-native-vector-icons/android/build.gradle
 @@ -35,5 +35,5 @@ repositories {


### PR DESCRIPTION
This PR builds on top of #28 and implements selective inclusion of icon fonts in iOS release bundle (similar to what they do on Android).