### PR TITLE
start fixing android back button problem by preventing it

### DIFF
--- a/android/app/src/main/java/network/mobius/wallet/MainActivity.java
+++ b/android/app/src/main/java/network/mobius/wallet/MainActivity.java
@@ -23,4 +23,9 @@ public class MainActivity extends ReactActivity {
         setTheme(R.style.AppTheme);
         super.onCreate(savedInstanceState);
     }
+
+    @Override
+    public void invokeDefaultOnBackPressed() {
+        moveTaskToBack(true);
+    }
 }

--- a/src/Root.js
+++ b/src/Root.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { StatusBar, BackHandler } from 'react-native';
+import { StatusBar } from 'react-native';
 import { Provider } from 'react-redux';
 import SplashScreen from 'react-native-splash-screen';
 import { I18nextProvider } from 'react-i18next';
@@ -8,34 +8,13 @@ import i18n from 'utils/i18n';
 
 import store from 'state/store';
 
-import { navigators } from 'state/navigator';
 import Navigator from './Navigator';
 import { SafeArea } from './styles';
 
 class Root extends Component {
   componentDidMount() {
-    BackHandler.addEventListener('hardwareBackPress', this.handleBackPress);
-
     SplashScreen.hide();
   }
-
-  componentWillUnmount() {
-    BackHandler.removeEventListener('hardwareBackPress', this.handleBackPress);
-  }
-
-  handleBackPress = () => {
-    // if on the Autn screen there is nothign to navigate back so block default closing app
-    if (navigators.Auth) {
-      return true;
-    }
-
-    // need to test if the StackNavigator is on the root screen - if so return true (prevent default action of exiting app)
-    if (false) {
-      return true;
-    }
-
-    return false;
-  };
 
   render() {
     return (

--- a/src/Root.js
+++ b/src/Root.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { StatusBar } from 'react-native';
+import { StatusBar, BackHandler } from 'react-native';
 import { Provider } from 'react-redux';
 import SplashScreen from 'react-native-splash-screen';
 import { I18nextProvider } from 'react-i18next';
@@ -8,13 +8,34 @@ import i18n from 'utils/i18n';
 
 import store from 'state/store';
 
+import { navigators } from 'state/navigator';
 import Navigator from './Navigator';
 import { SafeArea } from './styles';
 
 class Root extends Component {
   componentDidMount() {
+    BackHandler.addEventListener('hardwareBackPress', this.handleBackPress);
+
     SplashScreen.hide();
   }
+
+  componentWillUnmount() {
+    BackHandler.removeEventListener('hardwareBackPress', this.handleBackPress);
+  }
+
+  handleBackPress = () => {
+    // if on the Autn screen there is nothign to navigate back so block default closing app
+    if (navigators.Auth) {
+      return true;
+    }
+
+    // need to test if the StackNavigator is on the root screen - if so return true (prevent default action of exiting app)
+    if (false) {
+      return true;
+    }
+
+    return false;
+  };
 
   render() {
     return (


### PR DESCRIPTION
for https://mobius-network.atlassian.net/browse/MOB-478 came up with idea of disabling back button when it would close the app (not navigate back or close an in-app screen). this is better than getting stuck on reopen.

don't know much react native so wasn't able to finish figuring out how to get the current navigator state to see if it is at the top level. the navigators......

i know if showing if (navigators.Auth) { ... } its in the Auth one which only has 1 layer so definitely block it then