### PR TITLE
24hr Change trend 'No data' placeholder

### DIFF
--- a/src/components/shared/AmountItem/AmountItem.js
+++ b/src/components/shared/AmountItem/AmountItem.js
@@ -36,21 +36,23 @@ class AmountItem extends Component {
 
   renderTrend() {
     const { change } = this.props;
-
+    const icon = change && change !== 0;
     const changeIconName = change > 0
       ? { color: '#69f0ae', name: 'caret-up' }
       : { color: '#ff5252', name: 'caret-down' };
-    const changeAmount = `${change} %`;
+    const changeAmount = change !== undefined ? `${change} %` : '-- %';
     return (
       <Trend>
         <SecondaryAmount>{changeAmount}</SecondaryAmount>
-        <IconChangeType>
-          <Icon
-            color={changeIconName.color}
-            name={changeIconName.name}
-            size={14}
-          />
-        </IconChangeType>
+        {icon && (
+          <IconChangeType>
+            <Icon
+              color={changeIconName.color}
+              name={changeIconName.name}
+              size={14}
+            />
+          </IconChangeType>
+        )}
       </Trend>
     );
   }


### PR DESCRIPTION
Hi, this is a follow-up PR to the previous trend enhancements, 

I noticed that there is a small amount of time during load that the values are not available and the current logic was showing undefined. I made a small change to display, "No data"

![img_8b9676def3a0-1](https://user-images.githubusercontent.com/7041980/47409080-8bd45180-d716-11e8-8e08-c10344e339d4.jpeg)

Here is the final result.
![update](https://user-images.githubusercontent.com/7041980/47409831-d951be00-d718-11e8-91cd-1849980ca2f6.png)

Ok, thank you.